### PR TITLE
Select:find() - Added Object Filtering.

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -43,16 +43,12 @@ class File extends Request {
     public function add($objectID, $filePath, $description = '') {
         $fileAsString = $this->encode($filePath);
 
-        $cmdbObject = new CMDBObject($this->api);
-
-        $fileObjectID = $cmdbObject->create(
+        $fileObjectID = $this->getCMDBObject()->create(
             'C__OBJTYPE__FILE',
             $description
         );
 
-        $cmdbCategory = new CMDBCategory($this->api);
-
-        $cmdbCategory->create(
+        $this->getCMDBCategory()->create(
             $fileObjectID,
             'C__CMDB__SUBCAT__FILE_VERSIONS',
             [
@@ -64,7 +60,7 @@ class File extends Request {
             false
         );
 
-        $cmdbCategory->create(
+        $this->getCMDBCategory()->create(
             $objectID,
             'C__CATG__FILE',
             [
@@ -95,9 +91,7 @@ class File extends Request {
             ];
         }
 
-        $cmdbObjects = new CMDBObjects($this->api);
-
-        $fileObjectIDs = $cmdbObjects->create($objects);
+        $fileObjectIDs = $this->getCMDBObjects()->create($objects);
 
         if (count($fileObjectIDs) !== count($files)) {
             throw new \Exception(sprintf(
@@ -166,13 +160,6 @@ class File extends Request {
         }
 
         $fileAsString = base64_encode(file_get_contents($filePath));
-
-        if ($fileAsString === false) {
-            throw new \Exception(sprintf(
-                'Cannot convert file "%s" to base64 string',
-                $filePath
-            ));
-        }
 
         if ($fileAsString === false) {
             throw new \Exception(sprintf(

--- a/src/Request.php
+++ b/src/Request.php
@@ -51,6 +51,11 @@ abstract class Request implements Calls {
      * @var \bheisig\idoitapi\CMDBObjects
      */
     private static $cmdbObjects;
+    /**
+     *
+     * @var \bheisig\idoitapi\CMDBObjects
+     */
+    private static $cmdbObject;
 
     /**
      *
@@ -82,5 +87,18 @@ abstract class Request implements Calls {
             self::$cmdbObjects = new CMDBObjects($this->api);
         }
         return self::$cmdbObjects;
+    }
+
+    /**
+     * Lasy Init Singleton Object
+     *
+     * @return \bheisig\idoitapi\CMDBObject
+     */
+    public function getCMDBObject()
+    {
+        if (! self::$cmdbObject) {
+            self::$cmdbObject = new CMDBObject($this->api);
+        }
+        return self::$cmdbObject;
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -50,13 +50,13 @@ abstract class Request implements Calls {
      *
      * @var \bheisig\idoitapi\CMDBObjects
      */
-    private $cmdbObjects;
+    private static $cmdbObjects;
 
     /**
      *
      * @var \bheisig\idoitapi\CMDBCategory
      */
-    private $cmdbCategory;
+    private static $cmdbCategory;
 
     /**
      * Lasy Init Singleton Category
@@ -65,10 +65,10 @@ abstract class Request implements Calls {
      */
     public function getCMDBCategory()
     {
-        if (! $this->cmdbCategory) {
-            $this->cmdbCategory = new CMDBCategory($this->api);
+        if (! self::$cmdbCategory) {
+            self::$cmdbCategory = new CMDBCategory($this->api);
         }
-        return $this->cmdbCategory;
+        return self::$cmdbCategory;
     }
 
     /**
@@ -78,9 +78,9 @@ abstract class Request implements Calls {
      */
     public function getCMDBObjects()
     {
-        if (! $this->cmdbObjects) {
-            $this->cmdbObjects = new CMDBObjects($this->api);
+        if (! self::$cmdbObjects) {
+            self::$cmdbObjects = new CMDBObjects($this->api);
         }
-        return $this->cmdbObjects;
+        return self::$cmdbObjects;
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -45,4 +45,42 @@ abstract class Request implements Calls {
         $this->api = $api;
     }
 
+
+    /**
+     *
+     * @var \bheisig\idoitapi\CMDBObjects
+     */
+    private $cmdbObjects;
+
+    /**
+     *
+     * @var \bheisig\idoitapi\CMDBCategory
+     */
+    private $cmdbCategory;
+
+    /**
+     * Lasy Init Singleton Category
+     *
+     * @return \bheisig\idoitapi\CMDBCategory
+     */
+    public function getCMDBCategory()
+    {
+        if (! $this->cmdbCategory) {
+            $this->cmdbCategory = new CMDBCategory($this->api);
+        }
+        return $this->cmdbCategory;
+    }
+
+    /**
+     * Lasy Init Singleton Object
+     *
+     * @return \bheisig\idoitapi\CMDBObjects
+     */
+    public function getCMDBObjects()
+    {
+        if (! $this->cmdbObjects) {
+            $this->cmdbObjects = new CMDBObjects($this->api);
+        }
+        return $this->cmdbObjects;
+    }
 }

--- a/src/Select.php
+++ b/src/Select.php
@@ -30,6 +30,43 @@ namespace bheisig\idoitapi;
 class Select extends Request {
 
     /**
+     *
+     * @var \bheisig\idoitapi\CMDBObjects
+     */
+    private $cmdbObjects;
+
+    /**
+     *
+     * @var \bheisig\idoitapi\CMDBCategory
+     */
+    private $cmdbCategory;
+
+    /**
+     * Lasy Init Singleton Category
+     *
+     * @return \bheisig\idoitapi\CMDBCategory
+     */
+    public function getCMDBCategory()
+    {
+        if (! $this->cmdbCategory) {
+            $this->cmdbCategory = new CMDBCategory($this->api);
+        }
+        return $this->cmdbCategory;
+    }
+
+    /**
+     * Lasy Init Singleton Object
+     *
+     * @return \bheisig\idoitapi\CMDBObjects
+     */
+    public function getCMDBObjects()
+    {
+        if (! $this->cmdbObjects) {
+            $this->cmdbObjects = new CMDBObjects($this->api);
+        }
+        return $this->cmdbObjects;
+    }
+    /**
      * Find objects by attribute
      *
      * @param string $category
@@ -42,15 +79,13 @@ class Select extends Request {
      * @throws \Exception on error
      */
     public function find($category, $attribute, $value, $filter = []) {
-        $cmdbObjects = new CMDBObjects($this->api);
-
         $limit = 100;
         $offset = 0;
 
         $objectIDs = [];
 
         while (true) {
-            $objects = $cmdbObjects->read($filter, $limit, $offset);
+            $objects = $this->getCMDBObjects()->read($filter, $limit, $offset);
 
             $count = count($objects);
 
@@ -64,9 +99,7 @@ class Select extends Request {
 
             unset($objects);
 
-            $cmdbCategory = new CMDBCategory($this->api);
-
-            $result = $cmdbCategory->batchRead(
+            $result = $this->getCMDBCategory()->batchRead(
                 $objectIDs,
                 [$category]
             );

--- a/src/Select.php
+++ b/src/Select.php
@@ -30,43 +30,6 @@ namespace bheisig\idoitapi;
 class Select extends Request {
 
     /**
-     *
-     * @var \bheisig\idoitapi\CMDBObjects
-     */
-    private $cmdbObjects;
-
-    /**
-     *
-     * @var \bheisig\idoitapi\CMDBCategory
-     */
-    private $cmdbCategory;
-
-    /**
-     * Lasy Init Singleton Category
-     *
-     * @return \bheisig\idoitapi\CMDBCategory
-     */
-    public function getCMDBCategory()
-    {
-        if (! $this->cmdbCategory) {
-            $this->cmdbCategory = new CMDBCategory($this->api);
-        }
-        return $this->cmdbCategory;
-    }
-
-    /**
-     * Lasy Init Singleton Object
-     *
-     * @return \bheisig\idoitapi\CMDBObjects
-     */
-    public function getCMDBObjects()
-    {
-        if (! $this->cmdbObjects) {
-            $this->cmdbObjects = new CMDBObjects($this->api);
-        }
-        return $this->cmdbObjects;
-    }
-    /**
      * Find objects by attribute
      *
      * @param string $category

--- a/src/Select.php
+++ b/src/Select.php
@@ -35,12 +35,13 @@ class Select extends Request {
      * @param string $category
      * @param string $attribute
      * @param mixed $value
+     * @param array $filter - see \bheisig\idoitapi\CMDBObjects::read()
      *
      * @return int[] List of object identifiers
      *
      * @throws \Exception on error
      */
-    public function find($category, $attribute, $value) {
+    public function find($category, $attribute, $value, $filter = []) {
         $cmdbObjects = new CMDBObjects($this->api);
 
         $limit = 100;
@@ -49,7 +50,7 @@ class Select extends Request {
         $objectIDs = [];
 
         while (true) {
-            $objects = $cmdbObjects->read([], $limit, $offset);
+            $objects = $cmdbObjects->read($filter, $limit, $offset);
 
             $count = count($objects);
 


### PR DESCRIPTION
By Prefiltering the Objects (i.e. by Type) the find method does not have to parse all objects.