### PR TITLE
Make readRecursively really recursively

### DIFF
--- a/src/CMDBLocationTree.php
+++ b/src/CMDBLocationTree.php
@@ -67,32 +67,32 @@ class CMDBLocationTree extends Request {
      * @param int $objectID Object identifier
      * @param int $status Filter relations by status: 2 = normal, 3 = archived, 4 = deleted
      * @param int $level Level of recursion, negative values for no limit. Default: No Limit
+
      * @return array
      *
      * @throws Exception on error
      */
     public function readRecursively(int $objectID, int $status = null, $level = -1): array {
-        
+
         $children = $this->read($objectID, $status);
 
         $tree = [];
-        if($level != 0)
-        {
-          foreach ($children as $child) {
-              if (!array_key_exists('id', $child)) {
-                  throw new RuntimeException('Broken result');
-              }
+        if ($level != 0) {
+            foreach ($children as $child) {
+                if (!array_key_exists('id', $child)) {
+                    throw new RuntimeException('Broken result');
+                }
 
-              $node = $child;
+                $node = $child;
 
-              $childChildren = $this->readRecursively((int) $child['id'], $status, $level-1);
+                $childChildren = $this->readRecursively((int) $child['id'], $status, $level-1);
 
-              if (count($childChildren) > 0) {
-                  $node['children'] = $childChildren;
-              }
+                if (count($childChildren) > 0) {
+                    $node['children'] = $childChildren;
+                }
 
-              $tree[] = $node;
-          }
+                $tree[] = $node;
+            }
         }
 
         return $tree;

--- a/src/CMDBLocationTree.php
+++ b/src/CMDBLocationTree.php
@@ -66,30 +66,33 @@ class CMDBLocationTree extends Request {
      *
      * @param int $objectID Object identifier
      * @param int $status Filter relations by status: 2 = normal, 3 = archived, 4 = deleted
-     *
+     * @param int $level Level of recursion, negative values for no limit. Default: No Limit
      * @return array
      *
      * @throws Exception on error
      */
-    public function readRecursively(int $objectID, int $status = null): array {
+    public function readRecursively(int $objectID, int $status = null, $level = -1): array {
+        
         $children = $this->read($objectID, $status);
 
         $tree = [];
+        if($level != 0)
+        {
+          foreach ($children as $child) {
+              if (!array_key_exists('id', $child)) {
+                  throw new RuntimeException('Broken result');
+              }
 
-        foreach ($children as $child) {
-            if (!array_key_exists('id', $child)) {
-                throw new RuntimeException('Broken result');
-            }
+              $node = $child;
 
-            $node = $child;
+              $childChildren = $this->readRecursively((int) $child['id'], $status, $level-1);
 
-            $childChildren = $this->readRecursively((int) $child['id'], $status);
+              if (count($childChildren) > 0) {
+                  $node['children'] = $childChildren;
+              }
 
-            if (count($childChildren) > 0) {
-                $node['children'] = $childChildren;
-            }
-
-            $tree[] = $node;
+              $tree[] = $node;
+          }
         }
 
         return $tree;

--- a/src/CMDBLocationTree.php
+++ b/src/CMDBLocationTree.php
@@ -83,7 +83,7 @@ class CMDBLocationTree extends Request {
 
             $node = $child;
 
-            $childChildren = $this->read((int) $child['id'], $status);
+            $childChildren = $this->readRecursively((int) $child['id'], $status);
 
             if (count($childChildren) > 0) {
                 $node['children'] = $childChildren;


### PR DESCRIPTION
<!--
First of all, thanks for your pull request!

By sending this pull request you accept the following conditions:

1.  I have read the code of conduct and accept it.
2.  I have read the contributing guidelines and accept them.
3.  I accept that my contribution will be licensed under the AGPLv3.
-->

CMDBLocationTree->readRecursively was not recursively, it just read the first level. This is fixed, an additional parameter $level to control the depth was added.

