### PR TITLE
Deprecated "assertRegExp" replaced by "assertMatchesRegularExpression"

### DIFF
--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -729,8 +729,8 @@ abstract class BaseTest extends TestCase {
      */
     protected function isConstant(string $value) {
         $this->assertNotEmpty($value);
-        $this->assertRegExp('/([A-Z0-9_]+)/', $value);
-        $this->assertRegExp('/^([A-Z]+)/', $value);
+        $this->assertMatchesRegularExpression('/([A-Z0-9_]+)/', $value);
+        $this->assertMatchesRegularExpression('/^([A-Z]+)/', $value);
     }
 
     protected function isValidResponse(array $response, array $request) {


### PR DESCRIPTION
<!--
Thanks for your pull request! Please take a few minutes to fill out the following sections.
-->

Short description
Deprecated "assertRegExp" replaced by "assertMatchesRegularExpression"
Long description
Deprecated "assertRegExp" replaced by "assertMatchesRegularExpression"

### Changed

-   BaseTest.php

### Fixed

-   Failing test because of deprecated method

### Confirmation

By sending this pull request I accept the following conditions:

-   [x] I have read the code of conduct and accept it.
-   [x] I have read the contributing guidelines and accept them.
-   [x] I accept that my contribution will be licensed under the AGPLv3.
