### PR TITLE
Edited the file 'Console.php'

### DIFF
--- a/src/Console/Console.php
+++ b/src/Console/Console.php
@@ -69,8 +69,8 @@ class Console extends Request {
         }
 
         if ($result['success'] === false) {
-            if(!strpos($method, 'console.ldap.sync') || !strpos($method, 'console.import.csv')
-                || !strpos($method, 'console.import.syslog'))
+            if(!strpos($method, 'console.ldap.sync') && !strpos($method, 'console.import.csv')
+                && !strpos($method, 'console.import.syslog'))
             {
                 throw new RuntimeException('Command failed');
             }

--- a/src/Console/Console.php
+++ b/src/Console/Console.php
@@ -64,8 +64,15 @@ class Console extends Request {
             throw new RuntimeException('Missing success status');
         }
 
-        if (!is_bool($result['success']) || $result['success'] === false) {
+        if (!is_bool($result['success'])) {
             throw new RuntimeException('Command failed');
+        }
+        
+        if ($result['success'] === false) {
+            if ($method != 'console.ldap.sync' && $method != 'console.import.csv' && $method != 'console.import.syslog'
+                && $method != 'console.import.csvprofiles'){
+                throw new RuntimeException('Success is false');
+            }
         }
 
         if (!array_key_exists('output', $result)) {

--- a/src/Console/Console.php
+++ b/src/Console/Console.php
@@ -67,11 +67,12 @@ class Console extends Request {
         if (!is_bool($result['success'])) {
             throw new RuntimeException('Command failed');
         }
-        
+
         if ($result['success'] === false) {
-            if ($method != 'console.ldap.sync' && $method != 'console.import.csv' && $method != 'console.import.syslog'
-                && $method != 'console.import.csvprofiles'){
-                throw new RuntimeException('Success is false');
+            if(!strpos($method, 'console.ldap.sync') || !strpos($method, 'console.import.csv')
+                || !strpos($method, 'console.import.syslog'))
+            {
+                throw new RuntimeException('Command failed');
             }
         }
 


### PR DESCRIPTION
<!--
Thanks for your pull request! Please take a few minutes to fill out the following sections.
-->
Starting with i-doit version "1.16", the developers have fixed the bug that you will no longer get "true" as "success" value when you have to get "false" as "success" value.

### Affected tests

- bheisig.idoitapi.Console.ImportTest.testListCSVImportProfiles
 - bheisig.idoitapi.Console.ImportTest.testImportFromCSVFile
- bheisig.idoitapi.Console.ImportTest.testImportFromSyslog
 - bheisig.idoitapi.Console.LDAPTest.testSync
- bheisig.idoitapi.Console.LDAPTest.testSyncUnknow
- bheisig.idoitapi.Console.LDAPTest.testSyncAll
