### PR TITLE
Used the 'str_contains' method instead of 'strpos'

### DIFF
--- a/src/Console/Console.php
+++ b/src/Console/Console.php
@@ -69,8 +69,8 @@ class Console extends Request {
         }
 
         if ($result['success'] === false) {
-            if(!strpos($method, 'console.ldap.sync') && !strpos($method, 'console.import.csv')
-                && !strpos($method, 'console.import.syslog'))
+            if((str_contains($method, 'console.ldap.sync') || str_contains($method, 'console.import.csv')
+                || str_contains($method, 'console.import.syslog')) === false)
             {
                 throw new RuntimeException('Command failed');
             }


### PR DESCRIPTION


Short description
Uses the 'str_contains' method instead of 'strpos', because the 'strpos' method is not the right method to use at this point.