### PR TITLE
Remove abandoned package that leads to failing builds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,6 @@
         "sclable/xml-lint": "^0.3.0",
         "sebastian/phpcpd": "^5 || ^4",
         "seld/jsonlint": "^1.7",
-        "sensiolabs/security-checker": "^6.0.3",
         "squizlabs/php_codesniffer": "^3.5.4",
         "symfony/dotenv": "^5.0.3"
     },
@@ -68,7 +67,6 @@
             "@composer system-check",
             "@composer lint",
             "@composer find-forbidden",
-            "@composer security-checker",
             "@composer phpcompatibility",
             "@composer phpcpd",
             "@composer phpcs",
@@ -106,7 +104,6 @@
         "phpunit-addon": "./vendor/bin/phpunit --configuration ./phpunit.xml --testdox --no-interaction --group addon",
         "phpunit-parallel": "./vendor/bin/paratest -p8 --phpunit ./vendor/bin/phpunit --configuration ./phpunit.xml --exclude-group unreleased,addon,open ./tests/",
         "phpunit-unreleased": "./vendor/bin/phpunit --configuration ./phpunit.xml --testdox --no-interaction --group unreleased",
-        "security-checker": "./vendor/bin/security-checker security:check ./composer.lock",
         "system-check": [
             "php --version",
             "php -m",
@@ -145,7 +142,6 @@
         "phpunit-addon": "Perform unit tests for add-on related API requests",
         "phpunit-parallel": "Perform unit tests in parallel",
         "phpunit-unreleased": "Perform unit tests for unreleased features",
-        "security-checker": "Look for dependencies with known security vulnerabilities",
         "system-check": "Run some system checks"
     },
     "extra": {


### PR DESCRIPTION
Remove the abandoned package `sensiolabs/security-checker` since it leads  to failing builds. This will already be handled by `roave/security-advisories`.

### Removed

-   package `sensiolabs/security-checker` from `composer.json`

### Confirmation

By sending this pull request I accept the following conditions:

-   [x] I have read the code of conduct and accept it.
-   [x] I have read the contributing guidelines and accept them.
-   [x] I accept that my contribution will be licensed under the AGPLv3.
